### PR TITLE
Simple Command-Line Interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,15 @@ following objectives in mind:
 
 KOBE needs the Kubernetes operator that needs to be installed in the
 Kubernetes cluster. To quickly install the KOBE operator in a
-Kubernetes cluster, run the following
+Kubernetes cluster, you can use the `kobectl` script found in the
+[bin](bin/) directory:
+
+```
+export PATH=`pwd`/bin:$PATH
+kobectl install operator .
+```
+
+Alternatively, you could run the following commends:
 
 ```
 kubectl apply -f operator/deploy/crds
@@ -57,9 +65,13 @@ needs to be done only once.
 ### Installation of Networking subsystem
 
 KOBE uses istio to support network delays between the different 
-deployments. To install istio you can consult the official 
+deployments. To install istio you can run the following:
+```
+kobectl install istio .
+```
+Alternatively, you can consult the official 
 [installation guide](https://istio.io/docs/setup/getting-started/) 
-or you type the following commands.
+or you can type the following commands.
 
 ```
 curl -L https://istio.io/downloadIstio | sh -
@@ -69,7 +81,11 @@ istioctl manifest apply --set profile=default
 
 ### Installation of the Evaluation Metrics Extraction subsystem
 
-To enable the evaluation metrics extraction subsystem, run the following
+To enable the evaluation metrics extraction subsystem, run
+```
+kobectl install efk .
+```
+or alternatively the following
 ```
 helm repo add elastic https://helm.elastic.co
 helm repo add kiwigrid https://kiwigrid.github.io
@@ -166,6 +182,11 @@ For more advanced control options for KOBE, use [kubectl](https://kubernetes.io/
 
 ## Removal
 
+To remove KOBE from your cluster, go to the run the following command:
+```
+kobectl purge .
+```
+To remove the operator manually, run
 ```
 kubectl delete -f operator/deploy/operator.yaml
 kubectl delete -f operator/deploy/role.yaml
@@ -174,8 +195,12 @@ kubectl delete -f operator/deploy/clusterrole.yaml
 kubectl delete -f operator/deploy/service_account.yaml
 kubectl delete -f operator/deploy/crds
 ```
-
-To remove the evaluation metrics extraction subsystem run
+To remove istio manually, run
+```
+./istio-1.6.0/bin/istioctl manifest generate --set profile=default | kubectl delete -f -
+kubectl delete namespace istio-system
+```
+To remove the evaluation metrics extraction subsystem manually, run
 ```
 helm delete --purge elasticsearch
 helm delete --purge kibana

--- a/README.md
+++ b/README.md
@@ -114,19 +114,55 @@ The typical workflow of defining a KOBE experiment is the following.
 Several examples of the above specifications can be found in the [examples](examples/) directory.
 
 In the following, we show the steps for deploying an experiment on a simple benchmark that comprises
-three queries over a semagrow federation of two virtuoso endpoints.
+three queries over a Semagrow federation of two Virtuoso endpoints.
+
+You can use the `kobectl` script found in the [bin](bin/) directory for cotrolling your experiments:
 
 ```
-kubectl apply -f examples/dataset-virtuoso/virtuosotemplate.yaml
-kubectl apply -f examples/benchmark-toybench/toybench-simple.yaml
+export PATH=`pwd`/bin:$PATH
+kobectl help
 ```
-Wait a little for the datasets to load and proceed as follows:
+
+First, apply the templates for Virtuoso and Semagrow:
 
 ```
-kubectl apply -f examples/federator-semagrow/semagrowtemplate.yaml
-kubectl apply -f examples/experiment-toybench/toyexp-simple.yaml
+kobectl apply examples/dataset-virtuoso/virtuosotemplate.yaml
+kobectl apply examples/federator-semagrow/semagrowtemplate.yaml
+```
+Then, apply the benchmark.
+
+```
+kobectl apply examples/benchmark-toybench/toybench-simple.yaml
+```
+Before running the experiment, you should verify that the datasets are loaded.
+Use the following command:
+```
+kobectl show benchmark toybench-simple
+```
+When the datasets are loaded, you should get the following output:
+```
+NAME  STATUS
+toy1  Running
+toy2  Running
+```
+Proceed now with the execution of the experiment:
+```
+kobectl apply examples/experiment-toybench/toyexp-simple.yaml
+```
+As perviously, you can review the state of the experiment with the following command:
+```
+kobectl show experiment toyexp-simple
 ```
 You can now view the evaluation metrics in the Kibana dashboards.
+
+For removing all of the above, issue the following commands:
+```
+kobectl delete experiment toyexp-simple
+kobectl delete benchmark toybench-simple
+kobectl delete federatortemplate semagrowtemplate
+kobectl delete datasettemplate virtuosotemplate
+```
+For more advanced control options for KOBE, use [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/).
 
 ## Removal
 

--- a/bin/kobectl
+++ b/bin/kobectl
@@ -194,7 +194,7 @@ case $COMMAND in
     echo "  federatortemplate(s),"
     echo "  datasettemplate(s)."
     echo ""
-    echo "for more anvanced control options for KOBE, use kubectl."
+    echo "for more advanced control options for KOBE, use kubectl."
     ;;
     
   ##############################################################################

--- a/bin/kobectl
+++ b/bin/kobectl
@@ -180,27 +180,136 @@ case $COMMAND in
   
   ##############################################################################
   
+  "install")
+    
+    USAGE="usage: kobectl install [component] [kobe-directory]"
+    COMPONENT=$2
+    KOBEDIR=$3
+    
+    if [ -z $COMPONENT ] || [ -z $KOBEDIR ]
+    then
+      echo $USAGE
+      exit
+    fi
+    
+    cd $KOBEDIR
+    
+    case $COMPONENT in
+      "operator")
+        OPERATOR="true"
+        ;;
+      "istio")
+        ISTIO="true"
+        ;;
+      "efk")
+        EFK="true"
+        ;;
+      "full")
+        OPERATOR="true"
+        ISTIO="true"
+        EFK="true"
+        ;;
+      *)
+        echo $USAGE
+        exit
+        ;;
+    esac
+    
+    if [ ! -z $OPERATOR ]
+    then
+      kubectl apply -f operator/deploy/crds
+      kubectl apply -f operator/deploy/service_account.yaml
+      kubectl apply -f operator/deploy/clusterrole.yaml
+      kubectl apply -f operator/deploy/clusterrole_binding.yaml
+      kubectl apply -f operator/deploy/role.yaml
+      kubectl apply -f operator/deploy/operator.yaml
+    fi
+    
+    if [ ! -z $ISTIO ]
+    then
+      curl -L https://istio.io/downloadIstio | sh -
+      /istio-1.6.?/bin/istioctl manifest apply --set profile=default
+    fi
+    
+    if [ ! -z $EFK ]
+    then
+      helm repo add elastic https://helm.elastic.co
+      helm repo add kiwigrid https://kiwigrid.github.io
+      helm install elastic/elasticsearch \
+            --name elasticsearch --set persistence.enabled=false \
+            --set replicas=1 --version 7.6.2
+      helm install elastic/kibana \
+            --name kibana --set service.type=NodePort --version 7.6.2
+      helm install \
+            --name fluentd -f operator/deploy/efk-config/fluentd-values.yaml \
+            kiwigrid/fluentd-elasticsearch --version 8.0.1
+      kubectl apply -f operator/deploy/efk-config/kobe-kibana-configuration.yaml
+    fi
+    
+    ;;
+  
+  ##############################################################################
+  
+  "purge")
+    
+    echo "This operation will uninstall KOBE from your system."
+    echo -n "Proceed (y/n)? "
+    read answer
+    
+    if [ "$answer" != "${answer#[Yy]}" ]
+    then
+      kubectl delete experiments.kobe.semagrow.org --all
+      kubectl delete benchmarks.kobe.semagrow.org --all
+      kubectl delete federatortemplates.kobe.semagrow.org --all
+      kubectl delete datasettemplates.kobe.semagrow.org --all
+      
+      kubectl delete -f operator/deploy/operator.yaml
+      kubectl delete -f operator/deploy/role.yaml
+      kubectl delete -f operator/deploy/clusterrole_binding.yaml
+      kubectl delete -f operator/deploy/clusterrole.yaml
+      kubectl delete -f operator/deploy/service_account.yaml
+      kubectl delete -f operator/deploy/crds
+      
+      helm delete --purge elasticsearch
+      helm delete --purge kibana
+      helm delete --purge fluentd
+      helm repo remove elastic
+      helm repo remove kiwigrid
+      kubectl delete jobs.batch kobe-kibana-configuration
+      kubectl delete configmaps kobe-kibana-config
+    fi
+    
+    ;;
+    
+  ##############################################################################
+  
   *)
     echo "kobectl controls the KOBE open benchmarking engine."
     echo ""
     echo "Commands:"
-    echo "  apply   apply a resource using a .yaml configuration file"
-    echo "  get     display all resources of specific type"
-    echo "  show    show the state of a benchmark or an experiment"
-    echo "  delete  delete a resource of specific  type"
-    echo "  help    print this message"
+    echo "  apply    apply a resource using a .yaml configuration file"
+    echo "  get      display all resources of specific type"
+    echo "  show     show the state of a benchmark or an experiment"
+    echo "  delete   delete a resource of specific type"
+    echo "  install  install KOBE components"
+    echo "  purge    uninstall KOBE"
+    echo "  help     print this message"
     echo ""
     echo "Usage:"
     echo "  kobectl apply [configuration_file]"
     echo "  kobectl get [resource_type]"
     echo "  kobectl show [resource_type] [resource]"
     echo "  kobectl delete [resource_type] [resource]"
+    echo "  kobectl install [component] [kobe-directory]"
+    echo "  kobectl purge"
     echo ""
     echo "[resource_type] can be any of:"
     echo "  benchmark(s),"
     echo "  experiment(s),"
     echo "  federatortemplate(s),"
     echo "  datasettemplate(s)."
+    echo ""
+    echo "[component] can be any of: operator, istio, efk, full"
     echo ""
     echo "for more advanced control options for KOBE, use kubectl."
     ;;

--- a/bin/kobectl
+++ b/bin/kobectl
@@ -228,7 +228,7 @@ case $COMMAND in
     if [ ! -z $ISTIO ]
     then
       curl -L https://istio.io/downloadIstio | sh -
-      /istio-1.6.?/bin/istioctl manifest apply --set profile=default
+      ./istio-1.6.*/bin/istioctl manifest apply --set profile=default
     fi
     
     if [ ! -z $EFK ]
@@ -252,6 +252,16 @@ case $COMMAND in
   
   "purge")
     
+    USAGE="usage: kobectl purge [kobe-directory]"
+    KOBEDIR=$2
+    
+    if [ -z $KOBEDIR ]
+    then
+      echo $USAGE
+      exit
+    fi
+    
+    cd $KOBEDIR
     echo "This operation will uninstall KOBE from your system."
     echo -n "Proceed (y/n)? "
     read answer
@@ -269,6 +279,10 @@ case $COMMAND in
       kubectl delete -f operator/deploy/clusterrole.yaml
       kubectl delete -f operator/deploy/service_account.yaml
       kubectl delete -f operator/deploy/crds
+      
+      ./istio-1.6.*/bin/istioctl manifest generate --set profile=default \
+        | kubectl delete -f -
+      kubectl delete namespace istio-system
       
       helm delete --purge elasticsearch
       helm delete --purge kibana
@@ -301,7 +315,7 @@ case $COMMAND in
     echo "  kobectl show [resource_type] [resource]"
     echo "  kobectl delete [resource_type] [resource]"
     echo "  kobectl install [component] [kobe-directory]"
-    echo "  kobectl purge"
+    echo "  kobectl purge [kobe-directory]"
     echo ""
     echo "[resource_type] can be any of:"
     echo "  benchmark(s),"

--- a/bin/kobectl
+++ b/bin/kobectl
@@ -1,0 +1,202 @@
+#!/bin/sh
+
+COMMAND=$1
+
+case $COMMAND in
+
+  ##############################################################################
+  
+  "apply")
+  
+    USAGE="usage: kobectl apply [configuration_file]"
+    CONF_FILE=$2
+    
+    if [ -e $CONF_FILE ]
+    then
+      echo $USAGE
+      exit
+    fi
+    
+    kubectl apply -f $CONF_FILE
+    
+    ;;
+    
+  ##############################################################################
+    
+  "get")
+  
+    USAGE="usage: kobectl get [resource_type]"
+    TYPE=$2
+    FLAGS="-o custom-columns=NAME:.metadata.name"
+    
+    if [ -e $TYPE ]
+    then
+      echo $USAGE
+      exit
+    fi
+    
+    case $TYPE in
+      "benchmark" | "benchmarks")
+        kubectl $FLAGS get benchmarks.kobe.semagrow.org
+        ;;
+      "experiment" | "experiments")
+        kubectl $FLAGS get experiments.kobe.semagrow.org
+        ;;
+      "federatortemplate" | "federatortemplates")
+        kubectl $FLAGS get federatortemplates.kobe.semagrow.org
+        ;;
+      "datasettemplate" | "datasettemplates")
+        kubectl $FLAGS get datasettemplates.kobe.semagrow.org
+        ;;
+      *)
+        echo $USAGE
+        ;;
+    esac
+    
+    ;;
+  
+  ##############################################################################
+  
+  "delete")
+    
+    USAGE="usage: kobectl delete [resource_type] [resource]"
+    TYPE=$2
+    RESOURCE=$3
+    
+    if [ -e $TYPE ] || [ -e $RESOURCE ]
+    then
+      echo $USAGE
+      exit
+    fi
+    
+    case $TYPE in
+      "benchmark" | "benchmarks")
+        kubectl delete benchmarks.kobe.semagrow.org $RESOURCE
+        ;;
+      "experiment" | "experiments")
+        kubectl delete experiments.kobe.semagrow.org $RESOURCE
+        ;;
+      "federatortemplate" | "federatortemplates")
+        kubectl delete federatortemplates.kobe.semagrow.org $RESOURCE
+        ;;
+      "datasettemplate" | "datasettemplates")
+        kubectl delete datasettemplates.kobe.semagrow.org $RESOURCE
+        ;;
+      *)
+        echo $USAGE
+        exit
+        ;;
+    esac
+    
+    ;;
+  
+  ##############################################################################
+  
+  "show")
+    
+    USAGE="usage: kobectl show [resource_type] [resource]"
+    TYPE=$2
+    RESOURCE=$3
+    
+    if [ -e $TYPE ] || [ -e $RESOURCE ]
+    then
+      echo $USAGE
+      exit
+    fi
+    
+    case $TYPE in
+      "benchmark" | "benchmarks")
+      
+        DATASETS=`kubectl get benchmarks.kobe.semagrow.org $RESOURCE \
+                          -o jsonpath="{.spec.datasets[*].name}"`
+        
+        OUTPUT="NAME STATUS\n"
+        
+        for DATASET in $DATASETS
+        do
+          STATUS=`kubectl get pod $DATASET-pod -n $RESOURCE \
+                          -o custom-columns=:.status.phase --no-headers`
+          
+          if [ $STATUS = "Running" ]
+          then
+            LOADED_S=`kubectl logs $DATASET-pod -n $RESOURCE -c maincontainer \
+                      | grep "Data stored successfully!"`
+            LOADED_V=`kubectl logs $DATASET-pod -n $RESOURCE -c maincontainer \
+                      | grep "Server online at 1111"`
+            LOADED_P=`kubectl logs $DATASET-pod -n $RESOURCE -c maincontainer \
+                      | grep "database system is ready to accept connections" \
+                      | wc -l | grep 2`
+            
+            if [ -e "$LOADED_S$LOADED_V$LOADED_P" ] 
+            then
+              echo STATUS = "Loading"
+            fi
+          fi
+          
+          OUTPUT="$OUTPUT$DATASET $STATUS\n"
+        done
+        
+        echo -n $OUTPUT | column -t
+        
+        ;;
+      
+      "experiment" | "experiments")
+        
+        NAMESPACE=`kubectl get experiments.kobe.semagrow.org $RESOURCE \
+                           -o jsonpath="{.spec.benchmark}"`
+        FEDERATOR=`kubectl get experiments.kobe.semagrow.org $RESOURCE \
+                           -o jsonpath="{.spec.federatorName}"`
+        FEDSTATUS=`kubectl get pod $FEDERATOR -n $NAMESPACE \
+                           -o custom-columns=:.status.phase --no-headers`
+        
+        JOBS=`kubectl get pods --no-headers \
+                      -o custom-columns=:.metadata.name,:.status.phase \
+              | grep $RESOURCE-evaluationjob`
+        
+        OUTPUT="NAME STATUS\n$FEDERATOR $FEDSTATUS\n$JOBS\n"
+        echo -n $OUTPUT | column -t        
+        ;;
+      
+      "federatortemplate" | "federatortemplates")
+        echo "Invalid resource type. Use the get command."
+        ;;
+      "datasettemplate" | "datasettemplates")
+        echo "Invalid resource type. Use the get command."
+        ;;
+      *)
+        echo $USAGE
+        ;;
+    esac
+    
+    ;;
+  
+  ##############################################################################
+  
+  *)
+    echo "kobectl controls the KOBE open benchmarking engine."
+    echo ""
+    echo "Commands:"
+    echo "  apply   apply a resource using a .yaml configuration file"
+    echo "  get     display all resources of specific type"
+    echo "  show    show the state of a benchmark or an experiment"
+    echo "  delete  delete a resource of specific  type"
+    echo "  help    print this message"
+    echo ""
+    echo "Usage:"
+    echo "  kobectl apply [configuration_file]"
+    echo "  kobectl get [resource_type]"
+    echo "  kobectl show [resource_type] [resource]"
+    echo "  kobectl delete [resource_type] [resource]"
+    echo ""
+    echo "[resource_type] can be any of:"
+    echo "  benchmark(s),"
+    echo "  experiment(s),"
+    echo "  federatortemplate(s),"
+    echo "  datasettemplate(s)."
+    echo ""
+    echo "for more anvanced control options for KOBE, use kubectl."
+    ;;
+    
+  ##############################################################################
+    
+esac

--- a/bin/kobectl
+++ b/bin/kobectl
@@ -11,7 +11,7 @@ case $COMMAND in
     USAGE="usage: kobectl apply [configuration_file]"
     CONF_FILE=$2
     
-    if [ -e $CONF_FILE ]
+    if [ -z $CONF_FILE ]
     then
       echo $USAGE
       exit
@@ -29,7 +29,7 @@ case $COMMAND in
     TYPE=$2
     FLAGS="-o custom-columns=NAME:.metadata.name"
     
-    if [ -e $TYPE ]
+    if [ -z $TYPE ]
     then
       echo $USAGE
       exit
@@ -37,16 +37,16 @@ case $COMMAND in
     
     case $TYPE in
       "benchmark" | "benchmarks")
-        kubectl $FLAGS get benchmarks.kobe.semagrow.org
+        kubectl get benchmarks.kobe.semagrow.org $FLAGS
         ;;
       "experiment" | "experiments")
-        kubectl $FLAGS get experiments.kobe.semagrow.org
+        kubectl get experiments.kobe.semagrow.org $FLAGS
         ;;
       "federatortemplate" | "federatortemplates")
-        kubectl $FLAGS get federatortemplates.kobe.semagrow.org
+        kubectl get federatortemplates.kobe.semagrow.org $FLAGS
         ;;
       "datasettemplate" | "datasettemplates")
-        kubectl $FLAGS get datasettemplates.kobe.semagrow.org
+        kubectl get datasettemplates.kobe.semagrow.org $FLAGS
         ;;
       *)
         echo $USAGE
@@ -63,7 +63,7 @@ case $COMMAND in
     TYPE=$2
     RESOURCE=$3
     
-    if [ -e $TYPE ] || [ -e $RESOURCE ]
+    if [ -z $TYPE ] || [ -z $RESOURCE ]
     then
       echo $USAGE
       exit
@@ -97,8 +97,9 @@ case $COMMAND in
     USAGE="usage: kobectl show [resource_type] [resource]"
     TYPE=$2
     RESOURCE=$3
+    FLAGS="-o custom-columns=NAME:.metadata.name"
     
-    if [ -e $TYPE ] || [ -e $RESOURCE ]
+    if [ -z $TYPE ] || [ -z $RESOURCE ]
     then
       echo $USAGE
       exit
@@ -106,7 +107,7 @@ case $COMMAND in
     
     case $TYPE in
       "benchmark" | "benchmarks")
-      
+        
         DATASETS=`kubectl get benchmarks.kobe.semagrow.org $RESOURCE \
                           -o jsonpath="{.spec.datasets[*].name}"`
         
@@ -115,7 +116,13 @@ case $COMMAND in
         for DATASET in $DATASETS
         do
           STATUS=`kubectl get pod $DATASET-pod -n $RESOURCE \
-                          -o custom-columns=:.status.phase --no-headers`
+                          -o custom-columns=:.status.phase --no-headers \
+                  2> /dev/null`
+          
+          if [ -z $STATUS ]
+          then
+            continue
+          fi
           
           if [ $STATUS = "Running" ]
           then
@@ -127,9 +134,9 @@ case $COMMAND in
                       | grep "database system is ready to accept connections" \
                       | wc -l | grep 2`
             
-            if [ -e "$LOADED_S$LOADED_V$LOADED_P" ] 
+            if [ -z "$LOADED_S$LOADED_V$LOADED_P" ]
             then
-              echo STATUS = "Loading"
+              STATUS="Loading"
             fi
           fi
           
@@ -147,21 +154,22 @@ case $COMMAND in
         FEDERATOR=`kubectl get experiments.kobe.semagrow.org $RESOURCE \
                            -o jsonpath="{.spec.federatorName}"`
         FEDSTATUS=`kubectl get pod $FEDERATOR -n $NAMESPACE \
-                           -o custom-columns=:.status.phase --no-headers`
+                           -o custom-columns=:.status.phase --no-headers \
+                   2< /dev/null`
         
         JOBS=`kubectl get pods --no-headers \
                       -o custom-columns=:.metadata.name,:.status.phase \
               | grep $RESOURCE-evaluationjob`
         
         OUTPUT="NAME STATUS\n$FEDERATOR $FEDSTATUS\n$JOBS\n"
-        echo -n $OUTPUT | column -t        
+        echo -n $OUTPUT | column -t
         ;;
       
       "federatortemplate" | "federatortemplates")
-        echo "Invalid resource type. Use the get command."
+        kubectl get federatortemplate.kobe.semagrow.org $RESOURCE $FLAGS
         ;;
       "datasettemplate" | "datasettemplates")
-        echo "Invalid resource type. Use the get command."
+        kubectl get datasettemplate.kobe.semagrow.org $RESOURCE $FLAGS
         ;;
       *)
         echo $USAGE

--- a/examples/experiment-toybench/toyexp-simple.yaml
+++ b/examples/experiment-toybench/toyexp-simple.yaml
@@ -1,7 +1,7 @@
 apiVersion: kobe.semagrow.org/v1alpha1
 kind: Experiment
 metadata:
-  name: toyexp
+  name: toyexp-simple
 spec:
   benchmark: toybench-simple
   federatorName: semagrow-toy-simple


### PR DESCRIPTION
Implementation of a simple cli shell script (cf. `bin/kobectl`) which offers an abstraction of the most essential `kubectl` commands for controlling KOBE benchmarks and experiments.

Usage:
```
$ kobectl help
kobectl controls the KOBE open benchmarking engine.

Commands:
  apply    apply a resource using a .yaml configuration file
  get      display all resources of specific type
  show     show the state of a benchmark or an experiment
  delete   delete a resource of specific type
  install  install KOBE components
  purge    uninstall KOBE
  help     print this message

Usage:
  kobectl apply [configuration_file]
  kobectl get [resource_type]
  kobectl show [resource_type] [resource]
  kobectl delete [resource_type] [resource]
  kobectl install [component] [kobe-directory]
  kobectl purge [kobe-directory]

[resource_type] can be any of:
  benchmark(s),
  experiment(s),
  federatortemplate(s),
  datasettemplate(s).

[component] can be any of: operator, istio, efk, full

for more advanced control options for KOBE, use kubectl.
```

Also, updated the README, so that the example is controlled using `kobectl` instead of `kubectl`.