### PR TITLE
Modify operator to work without istio installed

### DIFF
--- a/operator/pkg/controller/dataset/controller.go
+++ b/operator/pkg/controller/dataset/controller.go
@@ -366,6 +366,13 @@ func (r *ReconcileDataset) newSvc(m *api.EphemeralDataset) *corev1.Service {
 					Port: port.ContainerPort,
 				}
 				servicePorts = append(servicePorts, newPort)
+			} else {
+
+				newPort := corev1.ServicePort{
+					Name: port.Name,
+					Port: port.ContainerPort,
+				}
+				servicePorts = append(servicePorts, newPort)
 			}
 		}
 	}

--- a/operator/pkg/controller/dataset/controller.go
+++ b/operator/pkg/controller/dataset/controller.go
@@ -348,21 +348,18 @@ func (r *ReconcileDataset) reconcileSvc(instance *api.EphemeralDataset) (bool, e
 		}
 		return true, nil
 	} else if err != nil {
-		return true, err
+		return false, err
 	}
 
 	return false, nil
 }
 
 func (r *ReconcileDataset) newSvc(m *api.EphemeralDataset) *corev1.Service {
-	servicePorts := []corev1.ServicePort{{
-		Port: int32(m.Spec.SystemSpec.Port),
-		Name: "http",
-	}}
+	servicePorts := []corev1.ServicePort{}
 
 	for i, container := range m.Spec.SystemSpec.Containers {
 		for j, port := range container.Ports {
-			if port.ContainerPort != int32(m.Spec.SystemSpec.Port) {
+			if &port.Name == nil || port.Name == "" {
 
 				newPort := corev1.ServicePort{
 					Name: "http-" + strconv.Itoa(i) + strconv.Itoa(j),

--- a/operator/pkg/controller/federation/controller.go
+++ b/operator/pkg/controller/federation/controller.go
@@ -655,7 +655,7 @@ func (r *ReconcileFederation) reconcileSvc(instance *api.Federation) (bool, erro
 		}
 		return true, nil
 	} else if err != nil {
-		return true, err
+		return false, err
 	}
 	return false, nil
 }


### PR DESCRIPTION
This request modifies kobe-operator so that it can operate even if istio is not available in the cluster.
This functionality is useful when the experiments will not going to use network delays.